### PR TITLE
✨Fleet example changes

### DIFF
--- a/examples/fleet/main.go
+++ b/examples/fleet/main.go
@@ -97,7 +97,7 @@ func main() {
 			if err := client.Get(ctx, req.NamespacedName, pod); err != nil {
 				return reconcile.Result{}, err
 			}
-			log.Info(fmt.Sprintf("Retrieved pod %s:>%s/%s", cl.Name(), pod.Namespace, pod.Name))
+			log.Info("Reconciling pod", "ns", pod.GetNamespace(), "name", pod.Name, "uuid", pod.UID)
 
 			// Print any annotations that start with fleet.
 			for k, v := range pod.Labels {

--- a/examples/fleet/main.go
+++ b/examples/fleet/main.go
@@ -186,9 +186,7 @@ func (k *KindClusterProvider) Run(ctx context.Context, mgr manager.Manager) erro
 				k.log.Info("failed to create rest config", "error", err)
 				return false, nil // keep going
 			}
-			// Copy provider options and append the cluster name
-			clOptions := append(k.Options, cluster.WithName(clusterName))
-
+			clOptions := append([]cluster.Option{cluster.WithName(clusterName)}, k.Options...)
 			cl, err := cluster.New(cfg, clOptions...)
 			if err != nil {
 				k.log.Info("failed to create cluster", "error", err)

--- a/examples/fleet/main.go
+++ b/examples/fleet/main.go
@@ -97,7 +97,7 @@ func main() {
 			if err := client.Get(ctx, req.NamespacedName, pod); err != nil {
 				return reconcile.Result{}, err
 			}
-			log.Info("Reconciling pod", "ns", pod.GetNamespace(), "name", pod.Name, "uuid", pod.UID)
+			log.Info("Reconciling pod", "cluster", cl.Name(), "ns", pod.GetNamespace(), "name", pod.Name, "uuid", pod.UID)
 
 			// Print any annotations that start with fleet.
 			for k, v := range pod.Labels {
@@ -171,6 +171,7 @@ func (k *KindClusterProvider) Run(ctx context.Context, mgr manager.Manager) erro
 			}
 			k.lock.RLock()
 			if _, ok := k.clusters[clusterName]; ok {
+				k.lock.RUnlock()
 				continue
 			}
 			k.lock.RUnlock()
@@ -247,6 +248,8 @@ func (k *KindClusterProvider) Run(ctx context.Context, mgr manager.Manager) erro
 				delete(k.clusters, name)
 				delete(k.cancelFns, name)
 				k.lock.Unlock()
+
+				k.log.Info("Cluster removed", "cluster", name)
 			}
 		}
 

--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -619,9 +619,9 @@ func (cm *controllerManager) Engage(ctx context.Context, cl cluster.Cluster) err
 	// be reentrant via noop
 	cm.engagedClustersLock.RLock()
 	if _, ok := cm.engagedClusters[cl.Name()]; ok {
-		cm.engagedClustersLock.RUnlock()
 		return nil
 	}
+	cm.engagedClustersLock.RUnlock()
 
 	// add early because any engaged runnable could access it
 	cm.engagedClustersLock.Lock()

--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -619,6 +619,7 @@ func (cm *controllerManager) Engage(ctx context.Context, cl cluster.Cluster) err
 	// be reentrant via noop
 	cm.engagedClustersLock.RLock()
 	if _, ok := cm.engagedClusters[cl.Name()]; ok {
+		cm.engagedClustersLock.RUnlock()
 		return nil
 	}
 	cm.engagedClustersLock.RUnlock()


### PR DESCRIPTION
Hi @sttts,

First at all, let me please put some context about this PR.

Starting from the (amazing!!!) changes of [your PR](https://github.com/kubernetes-sigs/controller-runtime/pull/2726), my goal was  to create an operator that watch the changes at many clusters. I was able to create the POC, but I have to add some small changes reflected in this PR.

1. [manager/internal.go](https://github.com/sttts/controller-runtime/blob/sttts-cluster-support/pkg/manager/internal.go#L620C1-L624C3) file (in fact, the only real change 😄).

During my tests I was not able to `engage` a new cluster as the code was always hung at line  `627: cm.engagedClustersLock.Lock()`, as the lock was never `RUnlock(ed)`.

2. Small changes (I think are necessaries) for running the `fleet` test.

If this changes make sense for you, feel free to merge this PR or add them directly in your branch.
<br>

Note: I also try to run `make test` to validate these code changes, but I have some compiler errors.

```
pkg/builder/controller.go:1: : # sigs.k8s.io/controller-runtime/pkg/builder [sigs.k8s.io/controller-runtime/pkg/builder.test]
pkg/builder/controller_test.go:571:30: undefined: cluster.WatchEvent
pkg/builder/controller_test.go:844:21: undefined: cluster.WatchEvent
pkg/builder/controller_test.go:855:67: undefined: cluster.Watcher
pkg/builder/controller_test.go:860:18: undefined: cluster.WatchEvent
pkg/builder/controller_test.go:866:58: undefined: cluster.WatchEvent (typecheck)
....
```

I have not found any reference in the code to  `cluster.WatchEvent`. If you could provide to me some context about this error, I will be happy to review it.


Regards,

Iván